### PR TITLE
feat: add multi-GPU selection UI for training and inference

### DIFF
--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -29,6 +29,7 @@ import {
 } from "./types/runtime";
 import { useChatRuntimeStore } from "./stores/chat-runtime-store";
 import { Switch } from "@/components/ui/switch";
+import { useGpuVisibility } from "@/hooks";
 
 export const defaultInferenceParams = DEFAULT_INFERENCE_PARAMS;
 export type { InferenceParams } from "./types/runtime";
@@ -426,6 +427,7 @@ export function ChatSettingsPanel({
                   </Select>
                 </div>
               )}
+              <InferenceGpuSelector onReloadModel={onReloadModel} />
               <AutoHealToolCallsToggle />
               <MaxToolCallsSlider />
               <ToolCallTimeoutSlider />
@@ -554,5 +556,84 @@ function ChatTemplateSection({
         </div>
       </div>
     </CollapsibleSection>
+  );
+}
+
+function InferenceGpuSelector({
+  onReloadModel,
+}: {
+  onReloadModel?: () => void;
+}) {
+  const gpuVisibility = useGpuVisibility();
+  const gpuIds = useChatRuntimeStore((s) => s.inferenceGpuIds);
+  const setGpuIds = useChatRuntimeStore((s) => s.setInferenceGpuIds);
+  const isAuto = gpuIds === null;
+
+  if (gpuVisibility.devices.length <= 1) return null;
+
+  const toggleGpu = (index: number) => {
+    if (gpuIds === null) return;
+    const selected = gpuIds.includes(index);
+    if (selected) {
+      if (gpuIds.length <= 1) return;
+      setGpuIds(gpuIds.filter((id) => id !== index));
+    } else {
+      setGpuIds([...gpuIds, index].sort((a, b) => a - b));
+    }
+    onReloadModel?.();
+  };
+
+  const handleAutoToggle = (auto: boolean) => {
+    if (auto) {
+      setGpuIds(null);
+    } else {
+      setGpuIds(gpuVisibility.devices.map((d) => d.index));
+    }
+    onReloadModel?.();
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-xs font-medium">GPUs</div>
+          <div className="text-[11px] text-muted-foreground">
+            Select GPUs for model loading. Reload to apply.
+          </div>
+        </div>
+        <label className="flex items-center gap-1.5 cursor-pointer shrink-0">
+          <span className="text-[10px] text-muted-foreground">Auto</span>
+          <Switch
+            size="sm"
+            checked={isAuto}
+            onCheckedChange={handleAutoToggle}
+          />
+        </label>
+      </div>
+      <div className="flex flex-wrap gap-1">
+        {gpuVisibility.devices.map((gpu) => {
+          const selected = isAuto || (gpuIds?.includes(gpu.index) ?? false);
+          const shortName = gpu.name.replace(/NVIDIA\s*/i, "");
+          return (
+            <button
+              key={gpu.index}
+              type="button"
+              disabled={isAuto}
+              onClick={() => toggleGpu(gpu.index)}
+              className={`rounded-lg border px-2 py-0.5 text-[10px] transition-colors ${
+                isAuto
+                  ? "border-border/50 bg-muted/30 text-muted-foreground/50 cursor-default"
+                  : selected
+                    ? "cursor-pointer border-primary/40 bg-primary/10 text-primary"
+                    : "cursor-pointer border-border text-muted-foreground hover:bg-muted/50"
+              }`}
+            >
+              <span className="font-medium">{gpu.index}</span>
+              <span className="opacity-60"> {shortName} · {gpu.memory_total_gb}GB</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
   );
 }

--- a/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
@@ -371,7 +371,7 @@ export function useChatModelRuntime() {
               previousWasUnloaded = true;
             }
 
-            const { chatTemplateOverride, kvCacheDtype } = useChatRuntimeStore.getState();
+            const { chatTemplateOverride, kvCacheDtype, inferenceGpuIds } = useChatRuntimeStore.getState();
             const loadResponse = await loadModel({
               model_path: modelId,
               hf_token: null,
@@ -382,6 +382,7 @@ export function useChatModelRuntime() {
               trust_remote_code: paramsBeforeLoad.trustRemoteCode ?? false,
               chat_template_override: chatTemplateOverride,
               cache_type_kv: kvCacheDtype,
+              gpu_ids: inferenceGpuIds,
             });
 
             // If cancelled while loading, don't update UI to show

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -79,6 +79,7 @@ type ChatRuntimeStore = {
   maxToolCallsPerMessage: number;
   toolCallTimeout: number;
   kvCacheDtype: string | null;
+  inferenceGpuIds: number[] | null;
   defaultChatTemplate: string | null;
   chatTemplateOverride: string | null;
   activeThreadId: string | null;
@@ -104,6 +105,7 @@ type ChatRuntimeStore = {
   setMaxToolCallsPerMessage: (value: number) => void;
   setToolCallTimeout: (value: number) => void;
   setKvCacheDtype: (dtype: string | null) => void;
+  setInferenceGpuIds: (ids: number[] | null) => void;
   setChatTemplateOverride: (template: string | null) => void;
   setPendingAudio: (base64: string, name: string) => void;
   clearPendingAudio: () => void;
@@ -129,6 +131,7 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set) => ({
   maxToolCallsPerMessage: loadInt(MAX_TOOL_CALLS_KEY, 10),
   toolCallTimeout: loadInt(TOOL_CALL_TIMEOUT_KEY, 5),
   kvCacheDtype: null,
+  inferenceGpuIds: null,
   defaultChatTemplate: null,
   chatTemplateOverride: null,
   activeThreadId: null,
@@ -203,6 +206,7 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set) => ({
       return { toolCallTimeout };
     }),
   setKvCacheDtype: (kvCacheDtype) => set({ kvCacheDtype }),
+  setInferenceGpuIds: (inferenceGpuIds) => set({ inferenceGpuIds }),
   setChatTemplateOverride: (chatTemplateOverride) => set({ chatTemplateOverride }),
   setPendingAudio: (base64, name) =>
     set({ pendingAudioBase64: base64, pendingAudioName: name }),

--- a/studio/frontend/src/features/chat/types/api.ts
+++ b/studio/frontend/src/features/chat/types/api.ts
@@ -41,6 +41,7 @@ export interface LoadModelRequest {
   trust_remote_code?: boolean;
   chat_template_override?: string | null;
   cache_type_kv?: string | null;
+  gpu_ids?: number[] | null;
 }
 
 export interface ValidateModelResponse {

--- a/studio/frontend/src/features/studio/sections/progress-section.tsx
+++ b/studio/frontend/src/features/studio/sections/progress-section.tsx
@@ -26,7 +26,7 @@ import {
   useTrainingConfigStore,
   useTrainingRuntimeStore,
 } from "@/features/training";
-import { useGpuUtilization } from "@/hooks";
+import { useGpuUtilization, useGpuVisibility } from "@/hooks";
 import { cn } from "@/lib/utils";
 import {
   ChartAverageIcon,
@@ -103,8 +103,11 @@ export function ProgressSection(): ReactElement {
     })),
   );
 
+  const selectedGpuIds = useTrainingConfigStore((s) => s.selectedGpuIds);
+
   const { stopTrainingRun } = useTrainingActions();
   const gpu = useGpuUtilization(runtime.isTrainingRunning);
+  const gpuVisibility = useGpuVisibility();
   const [stopDialogOpen, setStopDialogOpen] = useState(false);
   const [stopRequested, setStopRequested] = useState(false);
 
@@ -291,11 +294,32 @@ export function ProgressSection(): ReactElement {
         </div>
 
         <div className="flex flex-col gap-3">
-          <div className="flex items-center justify-between">
-            <p className="text-xs font-medium text-muted-foreground">
-              GPU Monitor
-            </p>
-            <span className="text-[11px] text-muted-foreground">Live</span>
+          <div className="flex flex-col gap-1">
+            <div className="flex items-center justify-between">
+              <p className="text-xs font-medium text-muted-foreground">
+                GPU Monitor
+              </p>
+              <span className="text-[11px] text-muted-foreground">Live</span>
+            </div>
+            {gpuVisibility.devices.length > 1 && (
+              <div className="flex flex-wrap gap-1">
+                {gpuVisibility.devices.map((device) => {
+                  const active = selectedGpuIds === null || selectedGpuIds.includes(device.index);
+                  return (
+                    <span
+                      key={device.index}
+                      className={`rounded-md px-1.5 py-0.5 text-[10px] tabular-nums ${
+                        active
+                          ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-400"
+                          : "bg-muted/50 text-muted-foreground/50"
+                      }`}
+                    >
+                      GPU {device.index}
+                    </span>
+                  );
+                })}
+              </div>
+            )}
           </div>
           <div className="grid grid-cols-2 gap-2.5">
             <GpuStat

--- a/studio/frontend/src/features/studio/sections/training-section.tsx
+++ b/studio/frontend/src/features/studio/sections/training-section.tsx
@@ -5,6 +5,7 @@ import { SectionCard } from "@/components/section-card";
 import { Button } from "@/components/ui/button";
 import { ChartContainer } from "@/components/ui/chart";
 import type { ChartConfig } from "@/components/ui/chart";
+import { Switch } from "@/components/ui/switch";
 import {
   Tooltip,
   TooltipContent,
@@ -17,6 +18,7 @@ import {
   useTrainingConfigStore,
   validateTrainingConfig,
 } from "@/features/training";
+import { useGpuVisibility } from "@/hooks";
 import {
   Archive04Icon,
   ChartAverageIcon,
@@ -50,6 +52,9 @@ export function TrainingSection() {
     (!store.isAudioModel && store.isDatasetAudio === true);
   const configValidation = validateTrainingConfig(store);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const gpuVisibility = useGpuVisibility();
+  const isMultiGpu = gpuVisibility.devices.length > 1;
+  const isAutoGpu = store.selectedGpuIds === null;
 
   const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -97,6 +102,30 @@ export function TrainingSection() {
     toast.success("Parameters reset to model defaults");
   };
 
+  const toggleGpuId = (gpuIndex: number) => {
+    const currentIds = store.selectedGpuIds;
+    if (currentIds === null) return;
+    const isSelected = currentIds.includes(gpuIndex);
+    if (isSelected) {
+      // Don't allow deselecting the last GPU
+      if (currentIds.length <= 1) return;
+      store.setSelectedGpuIds(currentIds.filter((id) => id !== gpuIndex));
+    } else {
+      store.setSelectedGpuIds([...currentIds, gpuIndex].sort((a, b) => a - b));
+    }
+  };
+
+  const handleAutoToggle = (auto: boolean) => {
+    if (auto) {
+      store.setSelectedGpuIds(null);
+    } else {
+      // Switch to manual — pre-select all visible GPUs
+      store.setSelectedGpuIds(
+        gpuVisibility.devices.map((d) => d.index),
+      );
+    }
+  };
+
   return (
     <div data-tour="studio-training" className="col-span-1 xl:col-span-4">
       <SectionCard
@@ -106,12 +135,12 @@ export function TrainingSection() {
         accent="blue"
         className="md:min-h-[470px]"
       >
-        <div className="flex flex-col gap-4">
+        <div className={`flex flex-col ${isMultiGpu ? "gap-3" : "gap-4"}`}>
         {/* Loss chart */}
-        <div className="relative  ">
+        <div className="relative">
           <ChartContainer
             config={chartConfig}
-            className="h-[180px] w-full relative right-8 blur"
+            className={`${isMultiGpu ? "h-[140px]" : "h-[180px]"} w-full relative right-8 blur`}
           >
             <LineChart data={placeholderData} accessibilityLayer={true}>
               <CartesianGrid vertical={false} strokeDasharray="3 3" />
@@ -151,6 +180,49 @@ export function TrainingSection() {
           </div>
         </div>
 
+        {/* GPU Selection — only shown when multiple GPUs detected */}
+        {isMultiGpu && (
+          <div className="flex flex-col gap-1.5">
+            <div className="flex items-center justify-between">
+              <span className="text-xs font-medium text-muted-foreground">
+                GPUs
+              </span>
+              <label className="flex items-center gap-1.5 cursor-pointer">
+                <span className="text-[10px] text-muted-foreground">Auto</span>
+                <Switch
+                  size="sm"
+                  checked={isAutoGpu}
+                  onCheckedChange={handleAutoToggle}
+                />
+              </label>
+            </div>
+            <div className="flex flex-wrap gap-1">
+              {gpuVisibility.devices.map((gpu) => {
+                const selected = isAutoGpu || (store.selectedGpuIds?.includes(gpu.index) ?? false);
+                const shortName = gpu.name.replace(/NVIDIA\s*/i, "");
+                return (
+                  <button
+                    key={gpu.index}
+                    type="button"
+                    disabled={isAutoGpu}
+                    onClick={() => toggleGpuId(gpu.index)}
+                    className={`rounded-lg border px-2 py-0.5 text-[10px] transition-colors ${
+                      isAutoGpu
+                        ? "border-border/50 bg-muted/30 text-muted-foreground/50 cursor-default"
+                        : selected
+                          ? "cursor-pointer border-blue-300 bg-blue-50 text-blue-700 dark:border-blue-700 dark:bg-blue-950 dark:text-blue-300"
+                          : "cursor-pointer border-border text-muted-foreground hover:bg-muted/50"
+                    }`}
+                  >
+                    <span className="font-medium">{gpu.index}</span>
+                    <span className="opacity-60"> {shortName} · {gpu.memory_total_gb}GB</span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
         {/* Start/Stop */}
         <Button
           data-tour="studio-start"
@@ -173,53 +245,55 @@ export function TrainingSection() {
           <p className="text-xs text-red-500 leading-relaxed">{configValidation.message}</p>
         )}
 
-        {/* Upload / Save / Reset */}
-        <p className="text-xs text-muted-foreground">Training Config</p>
-        <div className="grid grid-cols-3 gap-2">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="outline"
-                size="sm"
-                className="cursor-pointer"
-                onClick={() => fileInputRef.current?.click()}
-              >
-                <HugeiconsIcon icon={CloudUploadIcon} className="size-3.5" />
-                Upload
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Load a saved YAML config</TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                data-tour="studio-save"
-                variant="outline"
-                size="sm"
-                className="cursor-pointer"
-                onClick={handleSaveConfig}
-              >
-                <HugeiconsIcon icon={Archive04Icon} className="size-3.5" />
-                Save
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Download current config as YAML</TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="outline"
-                size="sm"
-                className="cursor-pointer"
-                onClick={handleResetConfig}
-                disabled={!store.selectedModel}
-              >
-                <HugeiconsIcon icon={CleanIcon} className="size-3.5" />
-                Reset
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Reset to model defaults</TooltipContent>
-          </Tooltip>
+        {/* Upload / Save / Reset — compact */}
+        <div className="flex flex-col gap-1">
+          <p className="text-xs text-muted-foreground">Training Config</p>
+          <div className="grid grid-cols-3 gap-2">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="cursor-pointer"
+                  onClick={() => fileInputRef.current?.click()}
+                >
+                  <HugeiconsIcon icon={CloudUploadIcon} className="size-3.5" />
+                  Upload
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Load a saved YAML config</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  data-tour="studio-save"
+                  variant="outline"
+                  size="sm"
+                  className="cursor-pointer"
+                  onClick={handleSaveConfig}
+                >
+                  <HugeiconsIcon icon={Archive04Icon} className="size-3.5" />
+                  Save
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Download current config as YAML</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="cursor-pointer"
+                  onClick={handleResetConfig}
+                  disabled={!store.selectedModel}
+                >
+                  <HugeiconsIcon icon={CleanIcon} className="size-3.5" />
+                  Reset
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Reset to model defaults</TooltipContent>
+            </Tooltip>
+          </div>
         </div>
         <input
           ref={fileInputRef}

--- a/studio/frontend/src/features/training/api/mappers.ts
+++ b/studio/frontend/src/features/training/api/mappers.ts
@@ -108,5 +108,6 @@ export function buildTrainingStartPayload(
     tensorboard_dir: config.enableTensorboard
       ? config.tensorboardDir.trim() || null
       : null,
+    gpu_ids: config.selectedGpuIds ?? undefined,
   };
 }

--- a/studio/frontend/src/features/training/stores/training-config-store.ts
+++ b/studio/frontend/src/features/training/stores/training-config-store.ts
@@ -85,6 +85,7 @@ const initialState: TrainingConfigState = {
   isDatasetImage: null,
   isDatasetAudio: false,
   maxPositionEmbeddings: null,
+  selectedGpuIds: null,
   ...DEFAULT_HYPERPARAMS,
 };
 
@@ -547,6 +548,7 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
         setFinetuneMLPModules: (finetuneMLPModules) =>
           set({ finetuneMLPModules }),
         setTargetModules: (targetModules) => set({ targetModules }),
+        setSelectedGpuIds: (selectedGpuIds) => set({ selectedGpuIds }),
         canProceed: () => canProceedForStep(get()),
         reset: () => set(initialState),
         resetToModelDefaults: () => {
@@ -563,7 +565,7 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
     },
     {
       name: "unsloth_training_config_v1",
-      version: 8,
+      version: 9,
       migrate: (persisted, version) => {
         const s = persisted as Record<string, unknown>;
         if (version < 2 && s.datasetSubset == null && s.datasetConfig != null) {
@@ -592,6 +594,9 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
           s.datasetAssistantTemplate ??= "";
           s.datasetLabelMapping ??= {};
           s.datasetAdvisorNotification ??= null;
+        }
+        if (version < 9) {
+          s.selectedGpuIds ??= null;
         }
         return s as unknown as TrainingConfigStore;
       },

--- a/studio/frontend/src/features/training/types/api.ts
+++ b/studio/frontend/src/features/training/types/api.ts
@@ -54,6 +54,7 @@ export interface TrainingStartRequest {
   wandb_project: string | null;
   enable_tensorboard: boolean;
   tensorboard_dir: string | null;
+  gpu_ids?: number[] | null;
 }
 
 export interface TrainingStartResponse {

--- a/studio/frontend/src/features/training/types/config.ts
+++ b/studio/frontend/src/features/training/types/config.ts
@@ -81,6 +81,7 @@ export interface TrainingConfigState {
   finetuneMLPModules: boolean;
   targetModules: string[];
   maxPositionEmbeddings: number | null;
+  selectedGpuIds: number[] | null;
 }
 
 export interface TrainingConfigActions {
@@ -143,6 +144,7 @@ export interface TrainingConfigActions {
   setFinetuneAttentionModules: (value: boolean) => void;
   setFinetuneMLPModules: (value: boolean) => void;
   setTargetModules: (value: string[]) => void;
+  setSelectedGpuIds: (value: number[] | null) => void;
   canProceed: () => boolean;
   reset: () => void;
   resetToModelDefaults: () => void;

--- a/studio/frontend/src/hooks/index.ts
+++ b/studio/frontend/src/hooks/index.ts
@@ -4,6 +4,8 @@
 export { useDebouncedValue } from "./use-debounced-value";
 export { useGpuInfo } from "./use-gpu-info";
 export { useGpuUtilization } from "./use-gpu-utilization";
+export { useGpuVisibility } from "./use-gpu-visibility";
+export type { GpuDevice, GpuVisibility } from "./use-gpu-visibility";
 export { useHardwareInfo } from "./use-hardware-info";
 export { useHfModelSearch } from "./use-hf-model-search";
 export { useRecommendedModelVram } from "./use-recommended-model-vram";

--- a/studio/frontend/src/hooks/use-gpu-visibility.ts
+++ b/studio/frontend/src/hooks/use-gpu-visibility.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { authFetch } from "@/features/auth";
+import { useEffect, useState } from "react";
+
+export interface GpuDevice {
+  index: number;
+  name: string;
+  memory_total_gb: number;
+}
+
+export interface GpuVisibility {
+  available: boolean;
+  backend_cuda_visible_devices: string | null;
+  parent_visible_gpu_ids: number[];
+  devices: GpuDevice[];
+}
+
+const DEFAULT: GpuVisibility = {
+  available: false,
+  backend_cuda_visible_devices: null,
+  parent_visible_gpu_ids: [],
+  devices: [],
+};
+
+/**
+ * Fetch GPU visibility info from the backend once on mount.
+ * Returns the list of available GPUs with their names and VRAM.
+ */
+export function useGpuVisibility(): GpuVisibility {
+  const [data, setData] = useState<GpuVisibility>(DEFAULT);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetch() {
+      try {
+        const res = await authFetch("/api/system/gpu-visibility");
+        if (!res.ok || cancelled) return;
+        const json = (await res.json()) as GpuVisibility;
+        if (!cancelled) setData(json);
+      } catch {
+        // Silently ignore — single GPU fallback
+      }
+    }
+
+    void fetch();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return data;
+}


### PR DESCRIPTION
## Summary
- Add GPU selector to training section and chat inference settings using the backend `gpu-visibility` endpoint
- Hidden for single-GPU systems via progressive disclosure
- Training store persisted with migration v9; inference GPU selection triggers model reload

## Files changed (12)
All frontend-only changes

## Test plan
- [x] Verify GPU selector appears only on multi-GPU systems
- [x] Verify training starts with selected GPUs
- [x] Verify inference model loads on selected GPUs
- [x] Verify single-GPU systems see no UI changes