### PR TITLE
feat: multi-GPU frontend selection and monitoring

### DIFF
--- a/studio/frontend/src/components/gpu-selector.tsx
+++ b/studio/frontend/src/components/gpu-selector.tsx
@@ -1,0 +1,77 @@
+import { useEffect } from "react";
+import { Switch } from "@/components/ui/switch";
+import { useGpuVisibility } from "@/hooks/use-gpu-visibility";
+import { cn } from "@/lib/utils";
+
+interface GpuSelectorProps {
+  gpuAuto: boolean;
+  selectedGpuIds: number[];
+  onAutoChange: (auto: boolean) => void;
+  onGpuToggle: (gpuIndex: number) => void;
+}
+
+export function GpuSelector({
+  gpuAuto,
+  selectedGpuIds,
+  onAutoChange,
+  onGpuToggle,
+}: GpuSelectorProps) {
+  const { devices, parentVisibleGpuIds, isMultiGpu } = useGpuVisibility();
+
+  // Reconcile stale selections when GPU visibility changes
+  useEffect(() => {
+    if (gpuAuto || !isMultiGpu) return;
+    const valid = selectedGpuIds.filter((id) =>
+      parentVisibleGpuIds.includes(id),
+    );
+    if (valid.length === 0) {
+      onAutoChange(true);
+      return;
+    }
+    if (valid.length !== selectedGpuIds.length) {
+      for (const id of selectedGpuIds) {
+        if (!parentVisibleGpuIds.includes(id)) {
+          onGpuToggle(id);
+        }
+      }
+    }
+  }, [gpuAuto, isMultiGpu, selectedGpuIds, parentVisibleGpuIds, onAutoChange, onGpuToggle]);
+
+  if (!isMultiGpu) return null;
+
+  return (
+    <div className="flex items-center gap-2 flex-wrap">
+      <label className="flex items-center gap-1.5">
+        <Switch
+          checked={gpuAuto}
+          onCheckedChange={onAutoChange}
+          className="scale-75 origin-left"
+        />
+        <span className="text-[11px] text-muted-foreground">Auto</span>
+      </label>
+
+      <div className="flex items-center gap-1.5 flex-wrap">
+        {devices.map((device) => {
+          const selected = gpuAuto || selectedGpuIds.includes(device.index);
+          return (
+            <button
+              key={device.index}
+              type="button"
+              onClick={() => !gpuAuto && onGpuToggle(device.index)}
+              className={cn(
+                "rounded-full px-2 py-0.5 text-[11px] ring-1 transition-colors",
+                gpuAuto
+                  ? "opacity-40 pointer-events-none ring-foreground/10 text-muted-foreground"
+                  : selected
+                    ? "bg-foreground/10 text-foreground ring-foreground/15"
+                    : "bg-transparent text-muted-foreground ring-foreground/10 hover:bg-foreground/5",
+              )}
+            >
+              GPU {device.index} · {Math.round(device.memoryTotalGb)}GB
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/studio/frontend/src/components/gpu-selector.tsx
+++ b/studio/frontend/src/components/gpu-selector.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
 import { useEffect } from "react";
 import { Switch } from "@/components/ui/switch";
 import { useGpuVisibility } from "@/hooks/use-gpu-visibility";
@@ -8,6 +11,7 @@ interface GpuSelectorProps {
   selectedGpuIds: number[];
   onAutoChange: (auto: boolean) => void;
   onGpuToggle: (gpuIndex: number) => void;
+  onGpuIdsChange: (ids: number[]) => void;
 }
 
 export function GpuSelector({
@@ -15,12 +19,13 @@ export function GpuSelector({
   selectedGpuIds,
   onAutoChange,
   onGpuToggle,
+  onGpuIdsChange,
 }: GpuSelectorProps) {
   const { devices, parentVisibleGpuIds, isMultiGpu } = useGpuVisibility();
 
-  // Reconcile stale selections when GPU visibility changes
+  // If GPUs disappear between navigations, drop stale IDs or flip back to auto
   useEffect(() => {
-    if (gpuAuto || !isMultiGpu) return;
+    if (gpuAuto || !isMultiGpu || selectedGpuIds.length === 0) return;
     const valid = selectedGpuIds.filter((id) =>
       parentVisibleGpuIds.includes(id),
     );
@@ -29,13 +34,9 @@ export function GpuSelector({
       return;
     }
     if (valid.length !== selectedGpuIds.length) {
-      for (const id of selectedGpuIds) {
-        if (!parentVisibleGpuIds.includes(id)) {
-          onGpuToggle(id);
-        }
-      }
+      onGpuIdsChange(valid);
     }
-  }, [gpuAuto, isMultiGpu, selectedGpuIds, parentVisibleGpuIds, onAutoChange, onGpuToggle]);
+  }, [gpuAuto, isMultiGpu, selectedGpuIds, parentVisibleGpuIds, onAutoChange, onGpuIdsChange]);
 
   if (!isMultiGpu) return null;
 
@@ -44,7 +45,12 @@ export function GpuSelector({
       <label className="flex items-center gap-1.5">
         <Switch
           checked={gpuAuto}
-          onCheckedChange={onAutoChange}
+          onCheckedChange={(auto) => {
+            if (!auto && selectedGpuIds.length === 0) {
+              onGpuIdsChange(parentVisibleGpuIds);
+            }
+            onAutoChange(auto);
+          }}
           className="scale-75 origin-left"
         />
         <span className="text-[11px] text-muted-foreground">Auto</span>
@@ -63,7 +69,7 @@ export function GpuSelector({
                 gpuAuto
                   ? "opacity-40 pointer-events-none ring-foreground/10 text-muted-foreground"
                   : selected
-                    ? "bg-foreground/10 text-foreground ring-foreground/15"
+                    ? "bg-emerald-500/15 text-emerald-600 ring-emerald-500/25 dark:text-emerald-400"
                     : "bg-transparent text-muted-foreground ring-foreground/10 hover:bg-foreground/5",
               )}
             >

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -49,6 +49,8 @@ import {
 } from "./types/runtime";
 import { useChatRuntimeStore } from "./stores/chat-runtime-store";
 import { Switch } from "@/components/ui/switch";
+import { GpuSelector } from "@/components/gpu-selector";
+import { useGpuVisibility } from "@/hooks/use-gpu-visibility";
 
 export const defaultInferenceParams = DEFAULT_INFERENCE_PARAMS;
 export type { InferenceParams } from "./types/runtime";
@@ -287,6 +289,12 @@ export function ChatSettingsPanel({
   const kvDirty = kvCacheDtype !== loadedKvCacheDtype;
   const ctxDirty = customContextLength !== null;
   const modelSettingsDirty = kvDirty || ctxDirty;
+  const { isMultiGpu } = useGpuVisibility();
+  const gpuAuto = useChatRuntimeStore((s) => s.gpuAuto);
+  const gpuIds = useChatRuntimeStore((s) => s.gpuIds);
+  const setGpuAuto = useChatRuntimeStore((s) => s.setGpuAuto);
+  const setGpuIds = useChatRuntimeStore((s) => s.setGpuIds);
+  const toggleGpuId = useChatRuntimeStore((s) => s.toggleGpuId);
   const [customPresets, setCustomPresets] = useState<Preset[]>(() =>
     loadSavedCustomPresets(),
   );
@@ -570,6 +578,18 @@ export function ChatSettingsPanel({
                   <Switch
                     checked={params.trustRemoteCode ?? false}
                     onCheckedChange={set("trustRemoteCode")}
+                  />
+                </div>
+              )}
+              {!isGguf && isMultiGpu && (
+                <div className="pt-1">
+                  <div className="text-xs font-medium mb-1.5">GPU Selection</div>
+                  <GpuSelector
+                    gpuAuto={gpuAuto}
+                    selectedGpuIds={gpuIds}
+                    onAutoChange={setGpuAuto}
+                    onGpuToggle={toggleGpuId}
+                    onGpuIdsChange={setGpuIds}
                   />
                 </div>
               )}

--- a/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
@@ -374,7 +374,7 @@ export function useChatModelRuntime() {
               previousWasUnloaded = true;
             }
 
-            const { chatTemplateOverride, kvCacheDtype, customContextLength, ggufContextLength } = useChatRuntimeStore.getState();
+            const { chatTemplateOverride, kvCacheDtype, customContextLength, ggufContextLength, gpuAuto, gpuIds } = useChatRuntimeStore.getState();
             // GGUF: use custom context length, or 0 = model's native context
             // Non-GGUF: use the Max Seq Length slider value
             const effectiveMaxSeqLength = customContextLength != null
@@ -390,6 +390,7 @@ export function useChatModelRuntime() {
               trust_remote_code: paramsBeforeLoad.trustRemoteCode ?? false,
               chat_template_override: chatTemplateOverride,
               cache_type_kv: kvCacheDtype,
+              gpu_ids: ggufVariant ? undefined : (gpuAuto || gpuIds.length === 0 ? null : gpuIds),
             });
 
             // If cancelled while loading, don't update UI to show

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -16,6 +16,8 @@ const MAX_TOOL_CALLS_KEY = "unsloth_max_tool_calls_per_message";
 const TOOL_CALL_TIMEOUT_KEY = "unsloth_tool_call_timeout";
 const HF_TOKEN_KEY = "unsloth_hf_token";
 const INFERENCE_PARAMS_KEY = "unsloth_chat_inference_params";
+const GPU_AUTO_KEY = "unsloth_chat_gpu_auto";
+const GPU_IDS_KEY = "unsloth_chat_gpu_ids";
 let hasShownInferencePersistenceWarning = false;
 
 function canUseStorage(): boolean {
@@ -76,6 +78,27 @@ function saveString(key: string, value: string): void {
   if (!canUseStorage()) return;
   try {
     localStorage.setItem(key, value);
+  } catch {
+    // ignore
+  }
+}
+
+function loadIntArray(key: string, fallback: number[]): number[] {
+  if (!canUseStorage()) return fallback;
+  try {
+    const raw = localStorage.getItem(key);
+    if (raw === null) return fallback;
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((n: unknown) => typeof n === "number") : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function saveIntArray(key: string, value: number[]): void {
+  if (!canUseStorage()) return;
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
   } catch {
     // ignore
   }
@@ -176,7 +199,12 @@ type ChatRuntimeStore = {
     cachedTokens: number;
   } | null;
   modelLoading: boolean;
+  gpuAuto: boolean;
+  gpuIds: number[];
   setModelLoading: (loading: boolean) => void;
+  setGpuAuto: (auto: boolean) => void;
+  setGpuIds: (ids: number[]) => void;
+  toggleGpuId: (id: number) => void;
   setParams: (params: InferenceParams) => void;
   setModels: (models: ChatModelSummary[]) => void;
   setLoras: (loras: ChatLoraSummary[]) => void;
@@ -234,7 +262,27 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set) => ({
   pendingAudioName: null,
   contextUsage: null,
   modelLoading: false,
+  gpuAuto: loadBool(GPU_AUTO_KEY, true),
+  gpuIds: loadIntArray(GPU_IDS_KEY, []),
   setModelLoading: (loading) => set({ modelLoading: loading }),
+  setGpuAuto: (auto) => {
+    set({ gpuAuto: auto });
+    saveBool(GPU_AUTO_KEY, auto);
+  },
+  setGpuIds: (ids) => {
+    set({ gpuIds: ids });
+    saveIntArray(GPU_IDS_KEY, ids);
+  },
+  toggleGpuId: (id) =>
+    set((state) => {
+      const current = state.gpuIds;
+      const next = current.includes(id)
+        ? current.filter((g) => g !== id)
+        : [...current, id];
+      if (next.length === 0) return state;
+      saveIntArray(GPU_IDS_KEY, next);
+      return { gpuIds: next };
+    }),
   setParams: (params) =>
     set(() => {
       const persisted = saveInferenceParams(params);

--- a/studio/frontend/src/features/chat/types/api.ts
+++ b/studio/frontend/src/features/chat/types/api.ts
@@ -41,6 +41,7 @@ export interface LoadModelRequest {
   trust_remote_code?: boolean;
   chat_template_override?: string | null;
   cache_type_kv?: string | null;
+  gpu_ids?: number[] | null;
 }
 
 export interface ValidateModelResponse {

--- a/studio/frontend/src/features/studio/sections/progress-section.tsx
+++ b/studio/frontend/src/features/studio/sections/progress-section.tsx
@@ -19,6 +19,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { Progress } from "@/components/ui/progress";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { OPTIMIZER_OPTIONS } from "@/config/training";
 import { setTrainingCompareHandoff } from "@/features/chat";
 import {
@@ -40,7 +41,7 @@ import {
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Link, useNavigate } from "@tanstack/react-router";
-import { type ReactElement, type ReactNode, useState } from "react";
+import { type ReactElement, type ReactNode, useMemo, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { ChartSettingsSheet } from "./charts/chart-settings-sheet";
 import {
@@ -303,7 +304,15 @@ function LiveGpuPanel({
 }: {
   isTrainingRunning: boolean;
 }): ReactElement {
-  const gpu = useGpuUtilization(isTrainingRunning);
+  const { aggregate, devices } = useGpuUtilization(isTrainingRunning);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const isMultiGpu = devices.length > 1;
+
+  const safeIndex = Math.min(selectedIndex, Math.max(0, devices.length - 1));
+  const gpu = useMemo(
+    () => (isMultiGpu ? devices[safeIndex] ?? aggregate : aggregate),
+    [isMultiGpu, devices, safeIndex, aggregate],
+  );
 
   return (
     <div className="flex flex-col gap-3">
@@ -313,6 +322,26 @@ function LiveGpuPanel({
         </p>
         <span className="text-[11px] text-muted-foreground">Live</span>
       </div>
+
+      {isMultiGpu && (
+        <Tabs
+          value={String(safeIndex)}
+          onValueChange={(v) => setSelectedIndex(Number(v))}
+        >
+          <TabsList className="h-7 w-full">
+            {devices.map((d, i) => (
+              <TabsTrigger
+                key={d.index}
+                value={String(i)}
+                className="text-[11px] h-6 px-2"
+              >
+                GPU {d.index}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </Tabs>
+      )}
+
       <div className="grid grid-cols-2 gap-2.5">
         <GpuStat
           label="Utilization"

--- a/studio/frontend/src/features/studio/sections/training-section.tsx
+++ b/studio/frontend/src/features/studio/sections/training-section.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+import { GpuSelector } from "@/components/gpu-selector";
 import { SectionCard } from "@/components/section-card";
 import { Button } from "@/components/ui/button";
 import { ChartContainer } from "@/components/ui/chart";
@@ -107,7 +108,7 @@ export function TrainingSection() {
         accent="blue"
         className={hasMessage ? "min-h-studio-config-column" : "h-studio-config-column"}
       >
-        <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-4 h-full">
         {/* Loss chart */}
         <div className="relative  ">
           <ChartContainer
@@ -152,6 +153,13 @@ export function TrainingSection() {
           </div>
         </div>
 
+        <GpuSelector
+          gpuAuto={store.gpuAuto}
+          selectedGpuIds={store.gpuIds}
+          onAutoChange={store.setGpuAuto}
+          onGpuToggle={store.toggleGpuId}
+        />
+
         {/* Start/Stop */}
         <Button
           data-tour="studio-start"
@@ -175,8 +183,9 @@ export function TrainingSection() {
         )}
 
         {/* Upload / Save / Reset */}
-        <p className="text-xs text-muted-foreground">Training Config</p>
-        <div className="grid grid-cols-3 gap-2">
+        <div className="mt-auto flex flex-col gap-1.5">
+          <p className="text-xs text-muted-foreground">Training Config</p>
+          <div className="grid grid-cols-3 gap-2">
           <Tooltip>
             <TooltipTrigger asChild>
               <Button
@@ -222,13 +231,14 @@ export function TrainingSection() {
             <TooltipContent>Reset to model defaults</TooltipContent>
           </Tooltip>
         </div>
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept=".yaml,.yml"
-          className="hidden"
-          onChange={handleFileUpload}
-        />
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".yaml,.yml"
+            className="hidden"
+            onChange={handleFileUpload}
+          />
+        </div>
         </div>
       </SectionCard>
     </div>

--- a/studio/frontend/src/features/studio/sections/training-section.tsx
+++ b/studio/frontend/src/features/studio/sections/training-section.tsx
@@ -158,6 +158,7 @@ export function TrainingSection() {
           selectedGpuIds={store.gpuIds}
           onAutoChange={store.setGpuAuto}
           onGpuToggle={store.toggleGpuId}
+          onGpuIdsChange={store.setGpuIds}
         />
 
         {/* Start/Stop */}

--- a/studio/frontend/src/features/training/api/mappers.ts
+++ b/studio/frontend/src/features/training/api/mappers.ts
@@ -108,5 +108,6 @@ export function buildTrainingStartPayload(
     tensorboard_dir: config.enableTensorboard
       ? config.tensorboardDir.trim() || null
       : null,
+    gpu_ids: config.gpuAuto || config.gpuIds.length === 0 ? null : config.gpuIds,
   };
 }

--- a/studio/frontend/src/features/training/stores/training-config-store.ts
+++ b/studio/frontend/src/features/training/stores/training-config-store.ts
@@ -559,7 +559,7 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
             const next = current.includes(id)
               ? current.filter((g) => g !== id)
               : [...current, id];
-            if (next.length === 0) return {};
+            if (next.length === 0) return state;
             return { gpuIds: next };
           }),
         canProceed: () => canProceedForStep(get()),

--- a/studio/frontend/src/features/training/stores/training-config-store.ts
+++ b/studio/frontend/src/features/training/stores/training-config-store.ts
@@ -86,6 +86,8 @@ const initialState: TrainingConfigState = {
   isDatasetAudio: false,
   maxPositionEmbeddings: null,
   ...DEFAULT_HYPERPARAMS,
+  gpuAuto: true,
+  gpuIds: [],
 };
 
 // AbortController for in-flight dataset multimodal checks.
@@ -111,6 +113,8 @@ const NON_PERSISTED_STATE_KEYS: ReadonlySet<keyof TrainingConfigState> = new Set
   "isDatasetAudio",
   "trainOnCompletions",
   "maxPositionEmbeddings",
+  "gpuAuto",
+  "gpuIds",
 ]);
 
 function partializePersistedState(
@@ -547,6 +551,17 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
         setFinetuneMLPModules: (finetuneMLPModules) =>
           set({ finetuneMLPModules }),
         setTargetModules: (targetModules) => set({ targetModules }),
+        setGpuAuto: (value) => set({ gpuAuto: value }),
+        setGpuIds: (value) => set({ gpuIds: value }),
+        toggleGpuId: (id) =>
+          set((state) => {
+            const current = state.gpuIds;
+            const next = current.includes(id)
+              ? current.filter((g) => g !== id)
+              : [...current, id];
+            if (next.length === 0) return {};
+            return { gpuIds: next };
+          }),
         canProceed: () => canProceedForStep(get()),
         reset: () => set(initialState),
         resetToModelDefaults: () => {

--- a/studio/frontend/src/features/training/types/api.ts
+++ b/studio/frontend/src/features/training/types/api.ts
@@ -54,6 +54,7 @@ export interface TrainingStartRequest {
   wandb_project: string | null;
   enable_tensorboard: boolean;
   tensorboard_dir: string | null;
+  gpu_ids: number[] | null;
 }
 
 export interface TrainingStartResponse {

--- a/studio/frontend/src/features/training/types/config.ts
+++ b/studio/frontend/src/features/training/types/config.ts
@@ -81,6 +81,8 @@ export interface TrainingConfigState {
   finetuneMLPModules: boolean;
   targetModules: string[];
   maxPositionEmbeddings: number | null;
+  gpuAuto: boolean;
+  gpuIds: number[];
 }
 
 export interface TrainingConfigActions {
@@ -143,6 +145,9 @@ export interface TrainingConfigActions {
   setFinetuneAttentionModules: (value: boolean) => void;
   setFinetuneMLPModules: (value: boolean) => void;
   setTargetModules: (value: string[]) => void;
+  setGpuAuto: (value: boolean) => void;
+  setGpuIds: (value: number[]) => void;
+  toggleGpuId: (id: number) => void;
   canProceed: () => boolean;
   reset: () => void;
   resetToModelDefaults: () => void;

--- a/studio/frontend/src/hooks/index.ts
+++ b/studio/frontend/src/hooks/index.ts
@@ -10,4 +10,5 @@ export { useRecommendedModelVram } from "./use-recommended-model-vram";
 export { useHfDatasetSearch } from "./use-hf-dataset-search";
 export { useHfDatasetSplits } from "./use-hf-dataset-splits";
 export { useHfTokenValidation } from "./use-hf-token-validation";
+export { useGpuVisibility } from "./use-gpu-visibility";
 export { useInfiniteScroll } from "./use-infinite-scroll";

--- a/studio/frontend/src/hooks/use-gpu-utilization.ts
+++ b/studio/frontend/src/hooks/use-gpu-utilization.ts
@@ -4,8 +4,7 @@
 import { useEffect, useState } from "react";
 import { authFetch } from "@/features/auth";
 
-export interface GpuDeviceMetrics {
-  index: number;
+export interface GpuUtilization {
   gpu_utilization_pct: number | null;
   temperature_c: number | null;
   vram_used_gb: number | null;
@@ -16,15 +15,8 @@ export interface GpuDeviceMetrics {
   power_utilization_pct: number | null;
 }
 
-export interface GpuUtilization {
-  gpu_utilization_pct: number | null;
-  temperature_c: number | null;
-  vram_used_gb: number | null;
-  vram_total_gb: number | null;
-  vram_utilization_pct: number | null;
-  power_draw_w: number | null;
-  power_limit_w: number | null;
-  power_utilization_pct: number | null;
+export interface GpuDeviceMetrics extends GpuUtilization {
+  index: number;
 }
 
 const DEFAULT: GpuUtilization = {
@@ -37,8 +29,6 @@ const DEFAULT: GpuUtilization = {
   power_limit_w: null,
   power_utilization_pct: null,
 };
-
-const DEFAULT_DEVICE: GpuDeviceMetrics = { index: 0, ...DEFAULT };
 
 export interface GpuUtilizationResult {
   /** Aggregate metrics (backwards-compatible with single-GPU consumers). */

--- a/studio/frontend/src/hooks/use-gpu-utilization.ts
+++ b/studio/frontend/src/hooks/use-gpu-utilization.ts
@@ -1,77 +1,102 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+import { useEffect, useState } from "react";
 import { authFetch } from "@/features/auth";
-import { useEffect, useRef, useState } from "react";
+
+export interface GpuDeviceMetrics {
+  index: number;
+  gpu_utilization_pct: number | null;
+  temperature_c: number | null;
+  vram_used_gb: number | null;
+  vram_total_gb: number | null;
+  vram_utilization_pct: number | null;
+  power_draw_w: number | null;
+  power_limit_w: number | null;
+  power_utilization_pct: number | null;
+}
 
 export interface GpuUtilization {
-    available: boolean;
-    backend: string | null;
-    gpu_utilization_pct: number | null;
-    temperature_c: number | null;
-    vram_used_gb: number | null;
-    vram_total_gb: number | null;
-    vram_utilization_pct: number | null;
-    power_draw_w: number | null;
-    power_limit_w: number | null;
-    power_utilization_pct: number | null;
+  gpu_utilization_pct: number | null;
+  temperature_c: number | null;
+  vram_used_gb: number | null;
+  vram_total_gb: number | null;
+  vram_utilization_pct: number | null;
+  power_draw_w: number | null;
+  power_limit_w: number | null;
+  power_utilization_pct: number | null;
 }
 
 const DEFAULT: GpuUtilization = {
-    available: false,
-    backend: null,
-    gpu_utilization_pct: null,
-    temperature_c: null,
-    vram_used_gb: null,
-    vram_total_gb: null,
-    vram_utilization_pct: null,
-    power_draw_w: null,
-    power_limit_w: null,
-    power_utilization_pct: null,
+  gpu_utilization_pct: null,
+  temperature_c: null,
+  vram_used_gb: null,
+  vram_total_gb: null,
+  vram_utilization_pct: null,
+  power_draw_w: null,
+  power_limit_w: null,
+  power_utilization_pct: null,
 };
 
-/**
- * Poll `GET /api/train/hardware` for live GPU utilization stats.
- *
- * Only polls while `enabled` is true (i.e. training is running).
- * Polling interval defaults to 10 000 ms.
- */
+const DEFAULT_DEVICE: GpuDeviceMetrics = { index: 0, ...DEFAULT };
+
+export interface GpuUtilizationResult {
+  /** Aggregate metrics (backwards-compatible with single-GPU consumers). */
+  aggregate: GpuUtilization;
+  /** Per-device metrics. Length > 1 means multi-GPU. */
+  devices: GpuDeviceMetrics[];
+}
+
+const EMPTY_RESULT: GpuUtilizationResult = {
+  aggregate: DEFAULT,
+  devices: [],
+};
+
 export function useGpuUtilization(
-    enabled: boolean,
-    intervalMs = 10_000,
-): GpuUtilization {
-    const [data, setData] = useState<GpuUtilization>(DEFAULT);
-    const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  enabled: boolean,
+  intervalMs = 10_000,
+): GpuUtilizationResult {
+  const [result, setResult] = useState<GpuUtilizationResult>(EMPTY_RESULT);
 
-    useEffect(() => {
-        if (!enabled) {
-            // Reset when training stops so the cards show "--" again
-            setData(DEFAULT);
+  useEffect(() => {
+    if (!enabled) {
+      setResult(EMPTY_RESULT);
+      return;
+    }
+
+    let alive = true;
+
+    async function poll() {
+      try {
+        const visRes = await authFetch("/api/train/hardware/visible");
+        if (visRes.ok && alive) {
+          const data = await visRes.json();
+          const devices: GpuDeviceMetrics[] = data.devices ?? [];
+          if (devices.length > 0) {
+            setResult({ aggregate: devices[0], devices });
             return;
+          }
         }
-
-        let cancelled = false;
-
-        async function poll() {
-            try {
-                const res = await authFetch("/api/train/hardware");
-                if (!res.ok || cancelled) return;
-                const json = (await res.json()) as GpuUtilization;
-                if (!cancelled) setData(json);
-            } catch {
-                // Silently ignore — next poll will retry
-            }
+        const res = await authFetch("/api/train/hardware");
+        if (res.ok && alive) {
+          const agg = await res.json();
+          setResult({
+            aggregate: agg,
+            devices: [{ index: 0, ...agg }],
+          });
         }
+      } catch {
+        /* next poll will retry */
+      }
+    }
 
-        // Fetch immediately, then set up interval
-        void poll();
-        timerRef.current = setInterval(() => void poll(), intervalMs);
+    void poll();
+    const id = setInterval(() => void poll(), intervalMs);
+    return () => {
+      alive = false;
+      clearInterval(id);
+    };
+  }, [enabled, intervalMs]);
 
-        return () => {
-            cancelled = true;
-            if (timerRef.current) clearInterval(timerRef.current);
-        };
-    }, [enabled, intervalMs]);
-
-    return data;
+  return result;
 }

--- a/studio/frontend/src/hooks/use-gpu-visibility.ts
+++ b/studio/frontend/src/hooks/use-gpu-visibility.ts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { useState, useEffect } from "react";
+
+interface GpuDevice {
+  index: number;
+  name: string;
+  memoryTotalGb: number;
+}
+
+export interface GpuVisibility {
+  available: boolean;
+  devices: GpuDevice[];
+  parentVisibleGpuIds: number[];
+  isMultiGpu: boolean;
+}
+
+const EMPTY: GpuVisibility = {
+  available: false,
+  devices: [],
+  parentVisibleGpuIds: [],
+  isMultiGpu: false,
+};
+
+let cached: GpuVisibility | null = null;
+let fetchPromise: Promise<GpuVisibility> | null = null;
+
+async function fetchOnce(): Promise<GpuVisibility> {
+  if (cached) return cached;
+  if (fetchPromise) return fetchPromise;
+
+  fetchPromise = fetch("/api/system/gpu-visibility")
+    .then(async (res) => {
+      if (!res.ok) return EMPTY;
+      const data = await res.json();
+      const devices: GpuDevice[] = (data.devices ?? []).map(
+        (d: { index: number; name: string; memory_total_gb: number }) => ({
+          index: d.index,
+          name: d.name,
+          memoryTotalGb: d.memory_total_gb,
+        }),
+      );
+      const result: GpuVisibility = {
+        available: data.available ?? false,
+        devices,
+        parentVisibleGpuIds: data.parent_visible_gpu_ids ?? [],
+        isMultiGpu: devices.length > 1,
+      };
+      cached = result;
+      return result;
+    })
+    .catch(() => EMPTY);
+
+  return fetchPromise;
+}
+
+export function useGpuVisibility(): GpuVisibility {
+  const [info, setInfo] = useState<GpuVisibility>(cached ?? EMPTY);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchOnce().then((result) => {
+      if (!cancelled) setInfo(result);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return info;
+}

--- a/studio/frontend/src/hooks/use-gpu-visibility.ts
+++ b/studio/frontend/src/hooks/use-gpu-visibility.ts
@@ -50,7 +50,10 @@ async function fetchOnce(): Promise<GpuVisibility> {
       cached = result;
       return result;
     })
-    .catch(() => EMPTY);
+    .catch(() => {
+      fetchPromise = null;
+      return EMPTY;
+    });
 
   return fetchPromise;
 }
@@ -59,6 +62,7 @@ export function useGpuVisibility(): GpuVisibility {
   const [info, setInfo] = useState<GpuVisibility>(cached ?? EMPTY);
 
   useEffect(() => {
+    if (cached) return;
     let cancelled = false;
     fetchOnce().then((result) => {
       if (!cancelled) setInfo(result);


### PR DESCRIPTION
Frontend for unslothai/unsloth#4602

### GPU Selection
Shared `GpuSelector` component with Auto toggle + GPU badge pills (e.g. `GPU 0 · 24GB`).

**Auto ON** (default): sends `null`, 
**Auto OFF**: user clicks badges to select specific GPUs, sends `gpu_ids` array.

Single GPU systems: selector is hidden everywhere.

### Where it lives
- **Training card**: between loss chart and Start button
- **Chat settings**: Model collapsible section (non-GGUF only)
- **Progress monitor**: shadcn Tabs to switch perGPU utilization stats during training